### PR TITLE
Add BGPT MCP (scientific paper search)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ These sources are licensed under the MIT License or similar permissive licenses 
 | **Algomo** – [pipedream](https://mcp.pipedream.com/app/algomo) | Multilingual customer service via generative AI. | Pipedream |
 | **All‑Images.ai** – [pipedream](https://mcp.pipedream.com/app/all_images_ai) | Generate personalized, royalty‑free visuals for projects. | Pipedream |
 
+| **BGPT MCP** – [github](https://github.com/connerlambden/bgpt-mcp) | Search scientific papers with full‑text experimental data via hosted MCP server. | awesome‑mcp‑servers |
 ## Finance & Crypto
 
 | Server | Description | Source |


### PR DESCRIPTION
Adds [BGPT MCP](https://github.com/connerlambden/bgpt-mcp) — hosted MCP server for searching scientific papers with full-text experimental data.

- SSE + Streamable HTTP endpoints
- Tool: `search_papers`
- 50 free searches, no API key needed