### PR TITLE
Add NotFair (Google Ads MCP)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The following servers are maintained by companies and organisations providing pr
 | **AgentOps** – [github](https://github.com/AgentOps-AI/agentops-mcp) | Provide observability and tracing for debugging AI agents using the AgentOps API. | modelcontextprotocol/servers |
 | **AgentQL (tinyfish‑io)** – [github](https://github.com/tinyfish-io/agentql-mcp) | Enable AI agents to extract structured data from unstructured web content. | modelcontextprotocol/servers |
 | **Aiven** – [github](https://github.com/Aiven-Open/mcp-aiven) | Navigate Aiven projects and interact with PostgreSQL®, Apache Kafka®, ClickHouse® and OpenSearch® services. | modelcontextprotocol/servers |
+| **NotFair** – [github](https://github.com/nowork-studio/toprank) | Google Ads MCP server. Diagnose campaign performance (CPA, ROAS, search-term waste, quality scores), recommend optimizations (bids, budgets, negatives, ad copy), and execute approved changes via the Google Ads API with a built-in human-approval gate. Hosted, streamable-HTTP at notfair.co. | nowork-studio |
 
 ## Full List
 


### PR DESCRIPTION
Adding NotFair under Industry & Official Integrations. It's a Google Ads MCP server that lets Claude and other AI agents diagnose campaign performance, recommend optimizations, and execute approved changes via the Google Ads API.

Source: github.com/nowork-studio/toprank
Registry: io.github.nowork-studio/notfair (active in the official MCP registry)
Endpoint: streamable-http at notfair.co/api/mcp/google_ads

Free tier available. Happy to adjust the format if you'd prefer.